### PR TITLE
Remove inaccurate accuracy metric under completion bar

### DIFF
--- a/app/static/js/segmentation.js
+++ b/app/static/js/segmentation.js
@@ -146,7 +146,6 @@ function updateProgress() {
   const pct = Math.min(strokeCount * 5, 100);
   document.getElementById('progress-bar').style.width = pct + '%';
   document.getElementById('progress-pct').textContent = pct + '%';
-  document.getElementById('dice-score').textContent   = pct > 0 ? pct + '%' : '—';
 }
 
 // ── Resize ─────────────────────────────────────────────────────────────────────
@@ -209,7 +208,6 @@ document.getElementById('btn-submit').addEventListener('click', async () => {
     const result = await resp.json();
     if (result.ok) {
       const accuracyPct = (result.dice_score * 100).toFixed(1) + '%';
-      document.getElementById('dice-score').textContent   = accuracyPct;
       document.getElementById('progress-pct').textContent = '100%';
       document.getElementById('progress-bar').style.width = '100%';
       showModal(accuracyPct, result.xp_awarded, result.accuracy_pct);

--- a/app/templates/segmentation.html
+++ b/app/templates/segmentation.html
@@ -41,7 +41,6 @@
       <div class="h-2.5 bg-gray-700 rounded-full overflow-hidden">
         <div id="progress-bar" class="h-full bg-purple-400 transition-all duration-300" style="width:0%"></div>
       </div>
-      <p class="text-[10px] text-gray-500 mt-1.5 italic">Accuracy: <span id="dice-score">—</span></p>
     </div>
 
     <div>


### PR DESCRIPTION
Very small change in the segmentation game page. The bit removed was showing an inaccurate value and wasn't contributing to the gameplay experience.